### PR TITLE
Favour style-loader over browsersync for HMR.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,9 @@
 "use strict";
 
 var path = require("path");
+var express = require("express");
 var gulp = require("gulp");
 var gutil = require("gulp-util");
-var browserSync = require("browser-sync").create();
 var webpack = require("webpack");
 var webpackStream = require("webpack-stream");
 var webpackDevMiddleware = require("webpack-dev-middleware");
@@ -14,7 +14,7 @@ var webpackConfig = process.env.NODE_ENV === "production" ?
 
 
 // The development server (the recommended option for development)
-gulp.task("default", ["browser-sync"]);
+gulp.task("default", ["webpack-dev-server"]);
 
 // Production build
 gulp.task("build", ["webpack:build"]);
@@ -34,40 +34,31 @@ gulp.task("webpack:build", function() {
     .pipe(gulp.dest("dist/"));
 });
 
+
 /**
- * Wraps the webpack-dev-server in browser-sync.
- * Standard webpack-dev-server doesn't HMR for css-modules.
- * This task watches for any .css changes and notifies the server.
+ * A customized webpack-dev-server setup.
+ * Integrates hot-module-reloading.
  */
-gulp.task("browser-sync", function() {
+gulp.task("webpack-dev-server", function(callback) {
+  var app = express();
+  // Start a webpack-dev-server
   var compiler = webpack(webpackConfig);
 
-  browserSync.init({
-    ui: false,
-    ghostMode: false,
-    online: false,
-    open: false,
-    notify: false,
-    host: "localhost",
-    port: "8080",
-    xip: false,
-    server: {
-      baseDir: webpackConfig.devServer.contentBase,
-      middleware: [
-        webpackDevMiddleware(compiler, {
-          // server and middleware options
-          publicPath: webpackConfig.output.publicPath,
-          stats: {
-            colors: true
-          }
-        }),
-        webpackHotMiddleware(compiler)
-      ]
-    },
-    files: [
-      "./dist/*.css"
-    ]
-  }, function (err, bs) {
+  app.use(require("webpack-dev-middleware")(compiler, {
+    // server and middleware options
+    publicPath: webpackConfig.output.publicPath,
+    stats: {
+      colors: true
+    }
+  }));
+
+  app.use(require("webpack-hot-middleware")(compiler));
+
+  // app.get("*", function(req, res) {
+  //   res.sendFile(path.join(__dirname, "index.html"));
+  // });
+
+  app.listen(8080, "localhost", function(err) {
     if(err) throw new gutil.PluginError("webpack-dev-server", err);
     // Server listening
     gutil.log("[webpack-dev-server]", "http://localhost:8080");
@@ -78,3 +69,4 @@ gulp.task("browser-sync", function() {
     console.log("Compiling ... Wait for 'bundle is VALID'");
   });
 });
+

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-hmre": "^1.1.0",
-    "browser-sync": "^2.11.1",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
     "eventsource-polyfill": "^0.9.6",
+    "express": "^4.13.4",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "gulp": "^3.9.1",
@@ -77,7 +77,6 @@
     "webpack": "^1.12.13",
     "webpack-dev-middleware": "^1.5.1",
     "webpack-hot-middleware": "^2.7.1",
-    "webpack-stream": "^3.1.0",
-    "write-file-webpack-plugin": "^3.1.7"
+    "webpack-stream": "^3.1.0"
   }
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,9 +2,7 @@
 
 var path = require("path");
 var webpack = require("webpack");
-var ExtractTextPlugin = require("extract-text-webpack-plugin");
 var HtmlWebpackPlugin = require("html-webpack-plugin");
-var WriteFilePlugin = require('write-file-webpack-plugin');
 var poststylus = require("poststylus");
 var autoprefixer = require("autoprefixer");
 var srcPath = path.join(__dirname, "src");
@@ -56,8 +54,8 @@ module.exports = {
   module: {
     loaders: [
       { test: /\.(js|jsx)$/, include: srcPath, loader: "babel" },
-      { test: /\.css$/, exclude: /\.useable\.css$/, loader: ExtractTextPlugin.extract("style", "css!postcss") },
-      { test: /\.styl$/, loader: ExtractTextPlugin.extract("style", "css?sourceMap&modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!stylus") },
+      { test: /\.css$/, exclude: /\.useable\.css$/, loader: "style!css!postcss" },
+      { test: /\.styl$/, loaders: ["style?sourceMap", "css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]!stylus"] },
       { test: /\.json$/, loader: "json" },
       { test: /\.png$/, loader: "url" },
       { test: /\.jpg$/, loader: "file" }
@@ -74,16 +72,11 @@ module.exports = {
   postcss: [autoprefixer],
   // webpack plugins
   plugins: [
-    new ExtractTextPlugin(
-      "[name].css",
-      { allChunks: true }
-    ),
     new HtmlWebpackPlugin({
       favicon: path.join(srcPath, "assets/images/favicon.png"),
       hash: true,
       template: path.join(srcPath, "assets/index.html")
     }),
-    new WriteFilePlugin(),
     new webpack.DefinePlugin({
       "process.env.NODE_ENV": JSON.stringify("development"),
       "__DEV__": true


### PR DESCRIPTION
css-loader -> style-loader comes built in with HMR compatibility. No
need for browsersync and webpack-write-plugin. Simply enable sourcemaps
so there is no need to use extracttextplugin during development.
