### PR TITLE
Update react-router-redux 3.0.0 -> 4.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-lite": "0.0.23",
     "react-redux": "^4.4.0",
     "react-router": "^2.0.0",
-    "react-router-redux": "^3.0.0",
+    "react-router-redux": "^4.0.0",
     "redux": "^3.3.1",
     "redux-actions": "^0.9.1",
     "redux-promise": "^0.5.1",

--- a/src/containers/Root/Root.dev.jsx
+++ b/src/containers/Root/Root.dev.jsx
@@ -1,13 +1,18 @@
 import React from 'react'
 import { Provider } from 'react-redux'
+import { browserHistory } from 'react-router'
+import { syncHistoryWithStore } from 'react-router-redux'
 import configureStore from 'store/configureStore'
 import Routes from './Routes'
 import DevTools from 'containers/DevTools'
 
+const store = configureStore()
+const history = syncHistoryWithStore(browserHistory, store)
+
 export default (
-  <Provider store={ configureStore() }>
+  <Provider store={ store }>
     <div>
-      <Routes />
+      <Routes history={ history } />
       <DevTools />
     </div>
   </Provider>

--- a/src/containers/Root/Root.prod.jsx
+++ b/src/containers/Root/Root.prod.jsx
@@ -1,10 +1,15 @@
 import React from 'react'
 import { Provider } from 'react-redux'
+import { browserHistory } from 'react-router'
+import { syncHistoryWithStore } from 'react-router-redux'
 import configureStore from 'store/configureStore'
 import Routes from './Routes'
 
+const store = configureStore()
+const history = syncHistoryWithStore(browserHistory, store)
+
 export default (
-  <Provider store={ configureStore() }>
-    <Routes />
+  <Provider store={ store }>
+    <Routes history={ history } />
   </Provider>
 )

--- a/src/containers/Root/Routes.jsx
+++ b/src/containers/Root/Routes.jsx
@@ -1,14 +1,14 @@
 import React from 'react'
-import { Router, Route, Redirect, IndexRoute, browserHistory } from 'react-router'
+import { Router, Route, Redirect, IndexRoute } from 'react-router'
 
 /* Pages */
 import Home from 'pages/Home'
 import NotFound from 'pages/NotFound'
 
-export default function Routes() {
+export default function Routes({ history }) {
   const App = ({ children }) => children
   return (
-    <Router history={ browserHistory }>
+    <Router history={ history }>
       <Route path="/" component={ App }>
         <IndexRoute component={ Home } />
         <Redirect from="home" to="/" />

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux'
-import { routeReducer as routing } from 'react-router-redux'
+import { routerReducer as routing } from 'react-router-redux'
 import counter from './counter'
 
 const rootReducer = combineReducers({

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -1,23 +1,18 @@
 import { createStore, applyMiddleware, compose } from 'redux'
-import { browserHistory } from 'react-router'
-import { syncHistory } from 'react-router-redux'
 import thunk from 'redux-thunk'
 import promiseMiddleware from 'redux-promise'
 import reducers from 'reducers'
 import DevTools from 'containers/DevTools'
-const reduxRouterMiddleware = syncHistory(browserHistory)
 
 export default function configureStore(initialState) {
   const store = createStore(
     reducers,
     initialState,
     compose(
-      applyMiddleware(thunk, promiseMiddleware, reduxRouterMiddleware),
+      applyMiddleware(thunk, promiseMiddleware),
       DevTools.instrument()
     )
   )
-
-  reduxRouterMiddleware.listenForReplays(store)
 
   if (module.hot)
     module.hot.accept('reducers', () =>

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -1,6 +1,4 @@
 import { createStore, applyMiddleware, compose } from 'redux'
-import { browserHistory } from 'react-router'
-import { syncHistory } from 'react-router-redux'
 import thunk from 'redux-thunk'
 import promiseMiddleware from 'redux-promise'
 import reducers from 'reducers'
@@ -9,6 +7,6 @@ export default function configureStore(initialState) {
   return createStore(
     reducers,
     initialState,
-    applyMiddleware(thunk, promiseMiddleware, syncHistory(browserHistory))
+    applyMiddleware(thunk, promiseMiddleware)
   )
 }


### PR DESCRIPTION
History is isolated to react-router, and react-router-redux only
focuses on syncing the redux store with the history. This enhnaced
/instance/ of history must be the same history used for the routes. No
need for d react-router-redux middleware. Simply use the traditional
(intended) history functions: history.push, go, etc. Or, even better,
use react-router's Link. Good to go, will be tracked by redux.
